### PR TITLE
Reduce empty response rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ source env/bin/activate
 Run an API server on subnet 1 with the following command:
 
 ```bash
-PORT=<API_PORT> VAL_PORT=<VALIDATOR_AXON_PORT> EXPECTED_ACCESS_KEY=<ACCESS_KEY> python server.py --wallet.name <WALLET_NAME> --wallet.hotkey <WALLET_HOTKEY> --netuid <NETUID> --neuron.model_id mock --neuron.tasks math --neuron.task_p 1 --neuron.device cpu --neuron.axon_off
+PORT=<API_PORT> VAL_PORT=<VALIDATOR_AXON_PORT> VAL_IP=<VALIDATOR_AXON_IP> EXPECTED_ACCESS_KEY=<ACCESS_KEY> python server.py --wallet.name <WALLET_NAME> --wallet.hotkey <WALLET_HOTKEY> --netuid <NETUID> --neuron.model_id mock --neuron.tasks math --neuron.task_p 1 --neuron.device cpu --neuron.axon_off
 ```
 
 The command ensures that no GPU memory is used by the server, and that the large models used by the incentive mechanism are not loaded.
@@ -69,13 +69,14 @@ Environment variables:
 - EXPECTED_ACCESS_KEY: API access key.
 - PORT: API port.
 - VAL_PORT: Validator axon port, optional. Needed if there are multiple validators running the same hotkey on the network.
+- VAL_IP: Validator axon ip, optional. Needed if there are multiple validators running the same hotkey on the network.
 
 > Note: This command is subject to change as the project evolves.
 
 We recommend that you run the server using a process manager like PM2. This will ensure that the server is always running and will restart if it crashes. 
 
 ```bash
-PORT=<API_PORT> VAL_PORT=<VALIDATOR_AXON_PORT> pm2 start server.py --interpreter python3 --name sn1-api -- --wallet.name <WALLET_NAME> --wallet.hotkey <WALLET_HOTKEY> --netuid <NETUID> --neuron.model_id mock --neuron.tasks math --neuron.task_p 1 --neuron.device cpu --neuron.axon_off
+PORT=<API_PORT> VAL_PORT=<VALIDATOR_AXON_PORT> VAL_IP=<VALIDATOR_AXON_IP> pm2 start server.py --interpreter python3 --name sn1-api -- --wallet.name <WALLET_NAME> --wallet.hotkey <WALLET_HOTKEY> --netuid <NETUID> --neuron.model_id mock --neuron.tasks math --neuron.task_p 1 --neuron.device cpu --neuron.axon_off
 ```
 
 ### Run with Docker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/macrocosm-os/prompting.git
+git+https://github.com/macrocosm-os/prompting.git@00d67a40732b831ac26c3bfc644b5ace7655f22b
 aiohttp
 deprecated
 aiohttp_apispec>=2.2.3

--- a/validators/query_validators.py
+++ b/validators/query_validators.py
@@ -16,10 +16,13 @@ from .streamer import StreamChunk
 
 
 class ValidatorStreamManager(StreamManager):
-    def __init__(self, chunks_to_wait: int = 1, miners_to_wait: int = 2):
+    def __init__(self, chunks_to_wait: int = 2, miners_to_wait: int = 2):
         """Stream validator response, which is based on the miners streamed responses.
         
         Get the miner responses and streams the longest completion miner UID.
+        Args:
+            chunks_to_wait: The number of chunks to wait before starting to stream.
+            miners_to_wait: The number of miners to wait before starting to stream.
         """
         # TODO: Move UID chosing logic to front-end, and stream all responses from all the miners to front-end.
         # TODO: Make SN1 organic query to get the top incentive UIDs, e.g 1 top incentive and 4 random miners.

--- a/validators/query_validators.py
+++ b/validators/query_validators.py
@@ -109,7 +109,6 @@ class ValidatorStreamManager(StreamManager):
                         accumulated_response_len[miner_uid] += len(response_chunk)
                         accumulated_chunks_timings[miner_uid].append(time.perf_counter() - start_time)
 
-
                         if client_response is None:
                             client_response = StreamResponse(status=200, reason="OK")
                             client_response.headers["Content-Type"] = "application/json"

--- a/validators/sn1_validator_wrapper.py
+++ b/validators/sn1_validator_wrapper.py
@@ -42,12 +42,15 @@ class S1ValidatorAPI(ValidatorAPI):
             # As of now we are querying only OTF validatior.
             uids = [self.validator.metagraph.hotkeys.index(self.validator.wallet.hotkey.ss58_address)]
             axon = self.validator.metagraph.axons[uids[0]]
-            # TODO: Remove port setting.
-            # Temporary hack to override port, until organic scoring is not in main branch.
+            # TODO: Remove port and ip setting.
+            # Temporary hack to override port and ip.
             # Currently, two OTF validators are running (one is not setting weights),
             # and port can be overridden by validator without organic scoring.
             if (val_port := os.environ.get("VAL_PORT")) is not None:
                 axon.port = int(val_port)
+            if (val_ip := os.environ.get("VAL_IP")) is not None:
+                axon.ip = val_ip
+
             axons = [axon]
 
         else:


### PR DESCRIPTION
## Changes
- Fix error with wrong Validator IP.

- Reduce the empty response rate and wait for at least two miners to stream their chunks before choosing the miner with the longest combined completion:
  1. Wait for at least two miners to stream their chunks.
  2. Choose the miner with the longest combined completion.
  3. Ensure proper handling and streaming of chunks.
